### PR TITLE
support use_legacy_notifications in check creation

### DIFF
--- a/lib/Pingdom/Client.pm
+++ b/lib/Pingdom/Client.pm
@@ -359,6 +359,7 @@ sub check_create {
         'notifywhenbackup' => 'Bool',
         'url' => 'Str',
         'encryption' => 'Bool',
+        'use_legacy_notifications' => 'Bool',
         'port' => 'Int',
         'auth' => 'Str',
         'shouldcontain' => 'Str',


### PR DESCRIPTION
This is required to get the old style contact notification working (which is required because the new ones aren't in the API docs yet). It is currently undocumented, but working. Probably works for modify_check too, but haven't tried.
